### PR TITLE
Feature/retry policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 dist
 node_modules
+.env*

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ import { Config } from "@littlemissrobot/jsonapi-client";
 
 Config.setAll({
   // The location of JSON:API
-  baseUrl: "https://jsonapi.v5tevkp4nowisbi4sic7gv.site",
+  baseUrl: "https://xxxxx",
   
   // The client ID
-  clientId: "Hcj7OqJC0KTObYMmMNmVbG3c",
+  clientId: "xxxxx",
   
   // The client secret
-  clientSecret: "Rtqe9lNoXsp9w9blIaVVlEA5",
+  clientSecret: "xxxxx",
   
   // Defines how long (in ms) before a token expires it should be proactively refreshed. (default: 60000 or 1 minute)
   tokenExpirySafetyWindow: 60000,

--- a/README.md
+++ b/README.md
@@ -10,24 +10,26 @@
 ## Overview
 
 * [Installation](#1-installation)
-* [Config](#2-config)
-* [Models](#3-models)
-  * [Model mapping](#31-model-mapping)
-  * [Retrieving model instances](#32-retrieving-model-instances)
-  * [Automapping](#33-automapping)
-  * [Default macros](#34-default-macros)
-  * [Data gating](#35-data-gating)
-* [QueryBuilder](#4-querybuilder)
-  * [Filtering](#41-filtering)
-  * [Sorting](#42-sorting)
-  * [Grouping](#43-grouping)
-  * [Macros](#44-macros)
-  * [Pagination](#45-pagination)
-  * [Data gating](#46-data-gating)
-  * [Fetching resources](#47-fetching-resources)
-* [ResultSet](#5-resultset)
-  * [Methods](#51-methods)
-  * [Meta data](#52-meta-data)
+* [Initialization](#2-initialization)
+* [Events](#3-events)
+* [Models](#4-models)
+  * [Model mapping](#41-model-mapping)
+  * [Retrieving model instances](#42-retrieving-model-instances)
+  * [Automapping](#43-automapping)
+  * [Default macros](#44-default-macros)
+  * [Data gating](#45-data-gating)
+* [QueryBuilder](#5-querybuilder)
+  * [Filtering](#51-filtering)
+  * [Sorting](#52-sorting)
+  * [Grouping](#53-grouping)
+  * [Macros](#54-macros)
+  * [Pagination](#55-pagination)
+  * [Data gating](#56-data-gating)
+  * [Fetching resources](#57-fetching-resources)
+  * [Locale, HTTP cache, and all batch size](#58-locale-http-cache-and-all-batch-size)
+* [ResultSet](#6-resultset)
+  * [Methods](#61-methods)
+  * [Meta data](#62-meta-data)
 
 ## 1. Installation
 
@@ -35,32 +37,54 @@
 npm install @littlemissrobot/jsonapi-client
 ```
 
-## 2. Config
-First, set your JSON:API credentials.
+The package is **ESM-first** (`import`); Node can also load it via CommonJS (`require`) using the conditional `exports` entry in `package.json`.
+
+## 2. Initialization
+
+Call **`JsonApi.init`** once at startup with your JSON:API credentials and optional 
+tuning. This registers the internal service container (`config`, `client`, `auth`, `events`, `macros`, 
+`fetch policy`, and the `query` factory used by models).
 
 ```ts
-import { Config } from "@littlemissrobot/jsonapi-client";
+import { JsonApi } from "@littlemissrobot/jsonapi-client";
 
-Config.setAll({
-  // The location of JSON:API
-  baseUrl: "https://jsonapi.v5tevkp4nowisbi4sic7gv.site",
-  
-  // The client ID
-  clientId: "Hcj7OqJC0KTObYMmMNmVbG3c",
-  
-  // The client secret
-  clientSecret: "Rtqe9lNoXsp9w9blIaVVlEA5",
-  
-  // Defines how long (in ms) before a token expires it should be proactively refreshed. (default: 60000 or 1 minute)
-  tokenExpirySafetyWindow: 60000,
+JsonApi.init({
+  baseUrl: process.env.API_URL!,
+  clientId: process.env.API_CLIENT_ID!,
+  clientSecret: process.env.API_CLIENT_SECRET!,
+
+  // Optional — defaults below are merged for you when omitted:
+  tokenExpirySafetyWindow: 60000, // ms before token expiry to refresh proactively (default: 60000)
+  retryDelay: 1000,               // ms between retries (default: 1000)
+  maxRetries: 3,                  // amount of retries to attempt, 0 disables retries (default: 2)
 });
 ```
 
-## 3. Models
+After initialization you can read values through the **`config()`** facade when needed (for example in custom wiring).
+
+## 3. Events
+
+The library emits lifecycle events through an **`EventBus`**. Access it with **`events()`**, or 
+use **`on(event, listener)`** / **`off(listenerId)`** from the package root.
+
+| Event | Payload | Description |
+| ----- | ------- | ----------- |
+| `paramAdded` | `{ queryBuilder, name, value }` | A query parameter was added |
+| `preFetch` | `{ method, path, ... }` plus `url` | Before an HTTP request |
+| `postFetch` | Same shape as `preFetch` | After an HTTP response |
+| `retry` | `{ request, attempt }` | A failed request is being retried |
+| `preFind` | `{ queryBuilder, uuid }` | Before resolving a resource by id |
+| `postFind` | `{ queryBuilder, uuid, result }` | After resolving by id |
+| `generatingAuthToken` | `null` | OAuth token refresh starting |
+| `authTokenGenerated` | `{ token, expiryTime }` | New token obtained |
+
+
+
+## 4. Models
 Every resource fetched from JSON:API gets mapped to an entity or model. A good way to 
 start getting familiar with this package, is by making your first model.
 
-### 3.1 Model mapping
+### 4.1 Model mapping
 Override the default Model's map-method to provide your 
 model with data. In the map-method you'll have a 
 generic ResponseModel available that allows for safer object traversal 
@@ -84,10 +108,10 @@ export class Author extends Model
   async map(responseModel: ResponseModelInterface): Promise<DataProperties<Author>>
   {
     return {
-      id: responseModel.get<string>('id', ''),
-      firstName: responseModel.get<string>('first_name', ''),
-      lastName: responseModel.get<string>('lastName', ''),
-      isGilke: responseModel.get<string>('first_name', '') === 'Gilke',
+      id: responseModel.get('id', ''),
+      firstName: responseModel.get('first_name', ''),
+      lastName: responseModel.get('lastName', ''),
+      isGilke: responseModel.get('first_name', '') === 'Gilke',
     };
   }
 }
@@ -113,39 +137,40 @@ export class BlogPost extends Model
   async map(responseModel: ResponseModelInterface): Promise<DataProperties<BlogPost>>
   {
     return {
-      id: responseModel.get<string>('id', ''),
-      type: responseModel.get<string>('type', ''),
-      title: responseModel.get<string>('title', ''),
-      author: responseModel.hasOne<Author>('author'),
+      id: responseModel.get('id', ''),
+      type: responseModel.get('type', ''),
+      title: responseModel.get('title', ''),
+      author: await responseModel.hasOne<Author>('author'),
     };
   }
 }
 ```
 
-#### 3.1.1 Defining relationships
+#### 4.1.1 Defining relationships
 
 Method | Use case
 ------ | --------
 hasOne | The expected result is 1 instance of a model
-hasMany| The expected result is a ResultSet of model instances
+hasMany| The expected result is an array of model instances
 
-In the `map` method in your model:
+In the `map` method in your model, **`hasOne` and `hasMany` return promises** — await them:
+
 ```ts
 return {
-  author: responseModel.hasOne<Author>('author'),
-  blocks: responseModel.hasMany<Block>('blocks'),
+  author: await responseModel.hasOne<Author>('author'),
+  blocks: await responseModel.hasMany<Block>('blocks'),
 };
 ```
 
 Both the `hasOne` and `hasMany` methods on ResponseModel take two arguments: first, the property 
-on which the data of the relationship can be found. e.g. `responseModel.hasOne('author')`. 
-This depends on [Automapping](#automapping). If the type of 'author' (e.g. 'node--author') isn't registered to 
+on which the data of the relationship can be found. e.g. `await responseModel.hasOne('author')`. 
+This depends on [Automapping](#43-automapping). If the type of 'author' (e.g. 'node--author') isn't registered to 
 the correct model, the hasOne method will not be able to automatically map it to the right model. In that case you can 
 pass a second argument to the method to tell the library to which model you want that specific property to be mapped:
-`responseModel.hasOne('author', Author)`. The model passed as second argument will take precedence over automapping.
-Read more about [Automapping](#automapping).
+`await responseModel.hasOne('author', Author)`. The model passed as second argument will take precedence over automapping.
+Read more about [Automapping](#43-automapping).
 
-### 3.2 Retrieving model instances
+### 4.2 Retrieving model instances
 Every model provides a static method `query` to retrieve a QueryBuilder 
 specifically for fetching instances of this Model.
 ```ts
@@ -154,9 +179,9 @@ const queryBuilder = BlogPost.query();
 The QueryBuilder provides an easy way to dynamically and programmatically 
 build queries. When the QueryBuilder is instantiated through a Model's query-method, 
 every result will be an instance of the Model it was called on.
-More info on using the QueryBuilder can be found in the section [QueryBuilder](#querybuilder).
+More info on using the QueryBuilder can be found in the section [QueryBuilder](#5-querybuilder).
 
-### 3.3 Automapping
+### 4.3 Automapping
 
 When you're not creating your query builder from a specific model, or the response 
 of your query encounters different types, you can specify how and when the 
@@ -184,17 +209,21 @@ AutoMapper.register({
 In this example, when the query builder encounters a resource with any of these types, it will 
 automatically resolve it to the corresponding model.
 
-### 3.4 Default macros
+### 4.4 Default macros
 
-The QueryBuilder allows for macros. [More on macros here](#44-macros). 
+The QueryBuilder allows for macros. [More on macros here](#54-macros). 
 
 #### Default macros
 The library allows for macros to be executed by default, without explicitly calling the macro on a QueryBuilder instance. This can 
 be done by setting the `defaultMacro` property on a model. Whenever the model gets queried, it will now also make sure the macro gets called. 
 This can be a good approach when you only want to query published items for example.
 
+Register macros after **`JsonApi.init`** using the **`macros()`** facade (the same registry the container uses):
+
 ```ts
-MacroRegistry.registerMacro('published', (qb: QueryBuilder) => {
+import { macros, QueryBuilder } from "@littlemissrobot/jsonapi-client";
+
+macros().register('published', (qb: QueryBuilder) => {
   qb.where('published', '=', 1);
 });
 ```
@@ -211,9 +240,9 @@ export default class BlogPost extends Model {
 Please note that this macro will only work whenever you query that specific model. That means, whenever the model gets mapped from a query 
 of another model (it's encountered as a relationship of another model), it will not be set in effect.
 
-### 3.5 Data gating
+### 4.5 Data gating
 
-You can set a gate directly on a model, everytime the Model gets queried, it will first validate if the result can pass the gate. [More on data gating here](#46-data-gating).
+You can set a gate directly on a model, everytime the Model gets queried, it will first validate if the result can pass the gate. [More on data gating here](#56-data-gating).
 
 ```ts
 import { Model } from "@littlemissrobot/jsonapi-client";
@@ -227,29 +256,49 @@ export class Author extends Model {
 }
 ```
 
-## 4. QueryBuilder
+## 5. QueryBuilder
 The QueryBuilder provides an easy way to dynamically and programmatically
 build queries and provides a safe API to communicate with the JSON:API.
 
 #### Instantiating a new query builder
 Although it's more convenient to instantiate your query builder directly from the model, 
-it's still possible to create ad-hoc query builders, like so:
+it's still possible to create ad-hoc query builders after **`JsonApi.init`**.
+
+Recommended — use the **`query()`** facade (same factory `Model.query` uses internally):
+
 ```ts
-const queryBuilder = new QueryBuilder(new Client(), 'api/my_endpoint', (responseModel) => {
+import { query } from "@littlemissrobot/jsonapi-client";
+
+const queryBuilder = query('api/my_endpoint', (responseModel) => {
   return {
     id: responseModel.get('id'),
   };
 });
 ```
-The default QueryBuilder implementation will also be available by using the built-in Container. It is adviced to use this as construction method 
-for your QueryBuilder, this way you always have easy control over your dependencies in your application.
+
+Alternatively, construct **`QueryBuilder`** explicitly with client, event bus, and macro registry:
+
 ```ts
-const queryBuilder = Container.make('QueryBuilderInterface', 'api/my_endpoint', (responseModel) => {
+import { QueryBuilder, client, events, macros } from "@littlemissrobot/jsonapi-client";
+
+const queryBuilder = new QueryBuilder(client(), events(), macros(), 'api/my_endpoint', (responseModel) => {
+  return {
+    id: responseModel.get('id'),
+  };
+});
+```
+
+You can also resolve the query binding from the container:
+
+```ts
+import { container } from "@littlemissrobot/jsonapi-client";
+
+const queryBuilder = container().make('query', 'api/my_endpoint', (responseModel) => {
     return responseModel;
 });
 ```
 
-### 4.1 Filtering
+### 5.1 Filtering
 Filtering resources is as easy as calling the `where()` method on 
 a QueryBuilder instance. This method can be chained.
 ```ts
@@ -298,7 +347,7 @@ qb.where('category', 'IN', ['Rondleiding', 'Tentoonstelling', 'Lezing']);
 ```
 
 ```ts
-qb.where('name', 'ENDS WITH', 'Van Oyen');
+qb.where('name', 'ENDS_WITH', 'Van Oyen');
 ```
 
 For convenience reasons, some of these have an alias method:
@@ -319,7 +368,7 @@ qb.whereIsNull('title');
 qb.whereIsNotNull('title');
 ```
 
-### 4.2 Sorting
+### 5.2 Sorting
 
 ```ts
 BlogPost.query().sort('author.name', 'asc');
@@ -329,8 +378,8 @@ BlogPost.query().sort('author.name', 'asc');
 BlogPost.query().sort('author.name', 'desc');
 ```
 
-### 4.3 Grouping
-The QueryBuilder provides an easy-to-use (and understand) interface 
+### 5.3 Grouping
+The QueryBuilder provides an easy-to-use interface 
 for filter-grouping. Possible methods for grouping are `or` & `and`.
 
 OR:
@@ -358,20 +407,20 @@ BlogPost.query().group('and', (qb: QueryBuilder) => {
 });
 ```
 
-### 4.4 Macros
+### 5.4 Macros
 As parts of your query can become quite long and complicated, it gets 
 very cumbersome to retype these again and again. Architecturally 
 it's also not the best approach, especially for parts of your query 
-that should be reusable (dry).
+that should be reusable (dry) on other queries.
 
 Because of this, you can abstract away query statements and register 
 them as macros, these can then be called on any QueryBuilder instance.
 
 #### Registering macros:
 ```ts
-import { QueryBuilder, MacroRegistry } from "@littlemissrobot/jsonapi-client";
+import { QueryBuilder, macros } from "@littlemissrobot/jsonapi-client";
 
-MacroRegistry.registerMacro('filterByAgeAndName', (qb: QueryBuilder, age, names) => {
+macros().register('filterByAgeAndName', (qb: QueryBuilder, age, names) => {
   qb.group('and', (qb: QueryBuilder) => {
     qb.where('author.age', '>', age);
     qb.group('or', (qb: QueryBuilder) => {
@@ -384,29 +433,31 @@ MacroRegistry.registerMacro('filterByAgeAndName', (qb: QueryBuilder, age, names)
 ```
 
 ```ts
-MacroRegistry.registerMacro('sortByAuthorAge', (qb: QueryBuilder) => {
+macros().register('sortByAuthorAge', (qb: QueryBuilder) => {
   qb.sort('author.age', 'desc');
 });
 ```
 #### Macro usage:
 ```ts
-BlogPost.query().macro('filterByAgeAndName', 35, ['Rein', 'Gilke']).macro('sortByAge');
+BlogPost.query().macro('filterByAgeAndName', 35, ['Rein', 'Gilke']).macro('sortByAuthorAge');
 ```
 
-### 4.5 Pagination
+### 5.5 Pagination
 ```ts
 BlogPost.query().paginate(1, 10);
 ```
 
-### 4.6 Data gating
+### 5.6 Data gating
 
 Data gating is the concept of setting prerequisites for data to be considered valid. For the result to end up in the final ResultSet, it must first pass this gate. The gate 
 function must return a truthy value for it to be considered passed. In other terms, this is a fancy way of filtering your results.
 
 ```ts
-Author.query().gate((responseModel) => {
-  return responseModel.get('name', '') === 'Gilke';
-});
+const gilkes = await Author.query()
+  .gate((responseModel) => {
+    return responseModel.get('name', '') === 'Gilke';
+  })
+  .get();
 ```
 
 In this example the query will only result in authors who have the name "Gilke".
@@ -414,10 +465,11 @@ In this example the query will only result in authors who have the name "Gilke".
 > ⚠️ **Warning**  
 > Gate functions do not stack. That means you can only use one gate for a query.
 
-The gate function will be called after fetching and before mapping. The added benefit of using data gating is you can define these on the model itself, so you don't have to call the `gate()` method on
-the QueryBuilder each time you want to fetch that resource. [More on defining gates on models here](#35-data-gating).
+The gate function will be called after fetching and before mapping. The added benefit of using data gating is you can define these 
+on the model itself, so you don't have to call the `gate()` method on the QueryBuilder each time you want to fetch that 
+resource. [More on defining gates on models here](#45-data-gating).
 
-### 4.7 Fetching resources
+### 5.7 Fetching resources
 
 On any QueryBuilder instance, you'll have these methods available for fetching 
 your resources:
@@ -437,27 +489,48 @@ await BlogPost.query().find('yourid');
 await BlogPost.query().all();
 ```
 
+Optional **`batchSize`** (default `50`) controls how many items are requested per page when walking all pages:
+```ts
+await BlogPost.query().all(25); // Uses a batchSize of 25
+```
+
 #### getRaw() - Gets all results from the query builder but doesn't map the results
 ```ts
 await BlogPost.query().getRaw();
 ```
 
-## 5. ResultSet
-### 5.1 Methods
-push, pop, map, forEach, filter, find, reduce, serialize
-
-The ResultSet tries to mimic an array, basic array methods are included. Whenever you want to transform
-your ResultSet to primitives (an array of plain objects), you can always call the `serialize` method:
+### 5.8 Locale, HTTP cache, and all batch size
 
 ```ts
-const primitiveBlogPosts = BlogPost.query().get().serialize();
+await BlogPost.query().setLocale('en').include(['hero']).where('status', '=', '1').all();
 ```
 
-### 5.2 Meta data
+```ts
+await BlogPost.query().noCache().get();
+```
+
+```ts
+// Fetch everything in smaller page sizes when the API supports it
+await BlogPost.query().all(25);
+```
+
+## 6. ResultSet
+### 6.1 Methods
+push, pop, map, forEach, filter, find, reduce, serialize, sort, toArray, concat
+
+The ResultSet tries to mimic an array; basic array methods are included. Whenever you want to transform
+your ResultSet to primitives (an array of plain objects), call **`serialize()`** on the **`ResultSet`** instance after **`await`**ing **`get()`** (or another fetch):
+
+```ts
+const resultSet = await BlogPost.query().get();
+const primitiveBlogPosts = resultSet.serialize();
+```
+
+### 6.2 Meta data
 How to access meta data of a ResultSet?
 ```ts
-const resultSet = BlogPost.query().get();
-const { query, count, performance } = resultSet.meta;
+const resultSet = await BlogPost.query().get();
+const { query, count, performance, excludedByGate } = resultSet.meta!;
 ```
 
 Property | Type | Description
@@ -467,16 +540,13 @@ performance | { query: number; mapping: number; } | Has benchmarks (duration in 
 count | number | The amount of resulting resources (not taking into account the pagination)
 pages | number | The amount of pages
 perPage | number | The amount of resources per page
+excludedByGate | number | Count of resources removed because they failed the active gate
 
-## Todo
-* Improved error reporting
-* events
-  * on specific models (model fetched, relationship loaded, model mapped, ...)
-  * query execution (query executed, query failed, ...)
-* Debug-mode (Logging requests, auth logging, LoggerInterface (?))
-* Nice to have: real lazy relationship fetching (vs includes)
-* meta when receiving model instance vs ResultSet?
-* Serialize by default option? Also include meta when serializing the ResultSet
+## Roadmap
+
+* Debug-mode (logging requests, auth logging, optional logger abstraction)
+* Meta shape when receiving a single model instance versus a ResultSet
+* Serialize-by-default options; optional inclusion of meta when serializing a ResultSet
 
 ## Credits & attribution
 <a href="https://www.flaticon.com/free-icons/bee-farming" title="bee farming icons">Bee farming icons created by SBTS2018 - Flaticon</a>

--- a/example/Event.ts
+++ b/example/Event.ts
@@ -1,0 +1,36 @@
+import type { DataProperties, ResponseModelInterface } from '../src/index';
+import { Model } from '../src/index';
+
+export default class Event extends Model {
+    public id!: string;
+    public title!: string;
+
+    /**
+     * @protected
+     */
+    protected static endpoint: string = 'api/event';
+
+    /**
+     * @protected
+     */
+    protected static include = [];
+
+    /**
+     * Override the default gate to only include events that have a title
+     * @param responseModel
+     */
+    public static gate(responseModel: ResponseModelInterface): boolean {
+        return responseModel.get('attributes.title', false);
+    }
+
+    /**
+     * Tell the model how to map from the response data
+     * @param response
+     */
+    async map(response: ResponseModelInterface): Promise<DataProperties<Event>> {
+        return {
+            id: response.get('id', ''),
+            title: response.get('attributes.title', ''),
+        };
+    }
+}

--- a/example/NewsArticle.ts
+++ b/example/NewsArticle.ts
@@ -1,0 +1,25 @@
+import type { DataProperties, ResponseModelInterface } from '../src/index';
+import { Model } from '../src/index';
+
+export default class NewsArticle extends Model {
+    public id!: string;
+    public title!: string;
+
+    /**
+     * @protected
+     */
+    protected static endpoint: string = 'api/news-article';
+
+    /**
+     * Tell the model how to map from the response data
+     * @param response
+     */
+    async map(response: ResponseModelInterface): Promise<DataProperties<NewsArticle>> {
+        console.log(response);
+
+        return {
+            id: response.get('id', ''),
+            title: response.get('attributes.title', ''),
+        };
+    }
+}

--- a/example/ResearchRecord.ts
+++ b/example/ResearchRecord.ts
@@ -1,0 +1,23 @@
+import type { DataProperties, ResponseModelInterface } from '../src/index';
+import { Model } from '../src/index';
+
+export default class ResearchRecord extends Model {
+    public id!: string;
+    public title!: string;
+
+    /**
+     * @protected
+     */
+    protected static endpoint: string = 'api/index/research_records';
+
+    /**
+     * Tell the model how to map from the response data
+     * @param response
+     */
+    async map(response: ResponseModelInterface): Promise<DataProperties<ResearchRecord>> {
+        return {
+            id: response.get('id', ''),
+            title: response.get('attributes.title', ''),
+        };
+    }
+}

--- a/example/demo.ts
+++ b/example/demo.ts
@@ -1,12 +1,28 @@
-import { client, JsonApi } from '../src/index';
+import * as process from 'node:process';
+import { client, events, JsonApi } from '../src/index';
+import NewsArticle from './NewsArticle';
 
 JsonApi.init({
-    baseUrl: '',
-    clientId: '',
-    clientSecret: '',
+    baseUrl: process.env.API_URL,
+    clientId: process.env.API_CLIENT_ID,
+    clientSecret: process.env.API_CLIENT_SECRET,
+    retryDelay: 1000,
+    maxRetries: 3,
 });
 
-await client().post(`api/webform/blabla`, {}, {});
+events().on('retry', (e) => {
+    console.log('-> RETRYING', e);
+});
+
+events().on('generatingAuthToken', () => {
+    console.log('-> GENERATING TOKEN!');
+});
+
+const newsArticles = await NewsArticle.query().get();
+console.log(newsArticles);
+
+const response = await client().get(`api/webform/blabla`, {});
+console.log(response);
 
 /*
 const data = await query('api/project')

--- a/example/demo.ts
+++ b/example/demo.ts
@@ -1,4 +1,5 @@
-import { client, JsonApi } from '../src/index';
+import { JsonApi } from '../src/index';
+import Event from './Event';
 
 JsonApi.init({
     baseUrl: '',
@@ -6,17 +7,9 @@ JsonApi.init({
     clientSecret: '',
 });
 
-await client().post(`api/webform/blabla`, {}, {});
+const query = await Event.query().include(['test', 'etest2']);
 
-/*
-const data = await query('api/project')
-    .setLocale('en')
-    .include(['hero'])
-    .where('status', '=', '1')
-    .all();
-
-console.log(data);
- */
+console.log(query.toString());
 
 /*
 // on('paramAdded', e => console.log('paramAdded', e));

--- a/example/demo.ts
+++ b/example/demo.ts
@@ -1,6 +1,6 @@
 import * as process from 'node:process';
-import { client, events, JsonApi } from '../src/index';
-import NewsArticle from './NewsArticle';
+import { events, JsonApi } from '../src/index';
+import ResearchRecord from './ResearchRecord';
 
 JsonApi.init({
     baseUrl: process.env.API_URL,
@@ -18,11 +18,13 @@ events().on('generatingAuthToken', () => {
     console.log('-> GENERATING TOKEN!');
 });
 
-const newsArticles = await NewsArticle.query().get();
-console.log(newsArticles);
+const researchRecords = await ResearchRecord.query().all();
+console.log(researchRecords.meta.original.facets);
+// const newsArticles = await NewsArticle.query().get();
+// console.log(newsArticles);
 
-const response = await client().get(`api/webform/blabla`, {});
-console.log(response);
+// const response = await client().get(`api/webform/blabla`, {});
+// console.log(response);
 
 /*
 const data = await query('api/project')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@littlemissrobot/jsonapi-client",
-  "version": "1.0.1",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@littlemissrobot/jsonapi-client",
-      "version": "1.0.1",
+      "version": "1.2.10",
       "license": "ISC",
       "devDependencies": {
         "@antfu/eslint-config": "^3.11.2",
         "@types/jest": "^29.5.14",
         "barrelsby": "^2.8.1",
+        "dotenv": "^17.4.2",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
         "prettier": "3.4.2",
@@ -3979,6 +3980,19 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prebuild": "barrelsby --directory src/types --delete --include .ts,.d.ts --location all",
     "prepare": "tsup && jest",
     "build": "tsup",
-    "example": "tsup --config tsup.example.config.ts && node ./dist/example/demo.js",
+    "example": "tsup --config tsup.example.config.ts && node -r dotenv/config ./dist/example/demo.js",
     "test": "jest"
   },
   "license": "ISC",
@@ -37,6 +37,7 @@
     "@antfu/eslint-config": "^3.11.2",
     "@types/jest": "^29.5.14",
     "barrelsby": "^2.8.1",
+    "dotenv": "^17.4.2",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "prettier": "3.4.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "author": "Rein Van Oyen",
   "description": "A lightweight library for seamless JSON API communication, featuring a powerful query builder and intuitive models for effortless data handling.",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Little-Miss-Robot/jsonapi-client.git"

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,87 +1,166 @@
 import type { AuthInterface } from './contracts/AuthInterface';
 import type { ClientInterface } from './contracts/ClientInterface';
+import type { EventBusInterface } from './contracts/EventBusInterface';
+import type { FetchPolicyInterface } from './contracts/FetchPolicyInterface';
+import type { TEventMap } from './types/event-bus';
+import type { HttpRequest, HttpRequestOptions, HttpRequestPath } from './types/request';
 import HttpError from './errors/HttpError';
 import InvalidJsonResponseError from './errors/InvalidJsonResponseError';
+import { sleep } from './utils/time';
+
+interface ExecuteOptions {
+    authRetryAttempted?: boolean
+}
 
 export default class Client implements ClientInterface {
-    /**
-     * The AuthInterface for this client
-     * @private
-     */
     private readonly auth: AuthInterface;
-
-    /**
-     * The base URL of the API
-     * @private
-     */
+    private readonly fetchPolicy: FetchPolicyInterface;
+    private readonly events: EventBusInterface<TEventMap>;
     private readonly baseUrl: string;
 
-    /**
-     * @param auth
-     * @param baseUrl
-     */
-    constructor(auth: AuthInterface, baseUrl: string) {
+    constructor(
+        auth: AuthInterface,
+        fetchPolicy: FetchPolicyInterface,
+        events: EventBusInterface<TEventMap>,
+        baseUrl: string,
+    ) {
         this.auth = auth;
+        this.fetchPolicy = fetchPolicy;
+        this.events = events;
         this.baseUrl = baseUrl;
     }
 
     /**
-     * Fetches the API with a GET request
+     * Executes a GET request
+     * @param path
+     * @param options
      */
-    public async get<T>(path: string, options: RequestInit = {}): Promise<T> {
-        const authHeaders = await this.auth.getHttpHeaders();
-        const url = `${this.baseUrl}/${path}`;
-        const response = await fetch(url, {
-            ...options,
+    public async get<T>(
+        path: HttpRequestPath,
+        options: HttpRequestOptions = {},
+    ): Promise<T> {
+        return await this.execute<T>({
             method: 'GET',
-            headers: new Headers({
-                ...authHeaders,
-                Accept: 'application/vnd.api+json',
-            }),
+            path,
+            options,
         });
-
-        const text = await response.text();
-
-        if (!response.ok) {
-            throw new HttpError(url, response, text);
-        }
-
-        try {
-            return JSON.parse(text) as T;
-        }
-        catch {
-            throw new InvalidJsonResponseError(url, response, text);
-        }
     }
 
     /**
-     * Fetches the API with a POST request
+     * Executes a POST request
+     * @param path
+     * @param body
+     * @param options
      */
-    public async post<T>(path: string, body: object, options: RequestInit = {}): Promise<T> {
-        const authHeaders = await this.auth.getHttpHeaders();
-        const url = `${this.baseUrl}/${path}`;
-        const response = await fetch(url, {
-            ...options,
+    public async post<T>(
+        path: HttpRequestPath,
+        body: object,
+        options: HttpRequestOptions = {},
+    ): Promise<T> {
+        return await this.execute<T>({
             method: 'POST',
-            headers: new Headers({
-                ...authHeaders,
-                'Accept': 'application/json',
-                'Content-Type': 'application/json',
-            }),
-            body: JSON.stringify(body),
+            path,
+            options: {
+                ...options,
+                body: JSON.stringify(body),
+            },
         });
+    }
 
+    /**
+     * Executes a request and handles the response (incl. errors, token refresh, retries)
+     * @param request
+     * @param executeOptions
+     * @private
+     */
+    private async execute<T>(
+        request: HttpRequest,
+        executeOptions: ExecuteOptions = {},
+    ): Promise<T> {
+        const response = await this.request(request);
+        const url = `${this.baseUrl}/${request.path}`;
         const text = await response.text();
 
-        if (!response.ok) {
+        if (response.ok) {
+            try {
+                return JSON.parse(text) as T;
+            }
+            catch {
+                throw new InvalidJsonResponseError(url, response, text);
+            }
+        }
+
+        if (response.status === 429) {
+            // We got a 429 ("Too Many Requests"), be gentle with the API and don't retry ;)
             throw new HttpError(url, response, text);
         }
 
-        try {
-            return JSON.parse(text) as T;
+        if (response.status === 401) {
+            // We got a 401 ("Unauthorized"), generate a new token and retry the request once
+            if (!executeOptions.authRetryAttempted) {
+                await this.auth.generateAuthToken();
+
+                return await this.execute<T>(request, {
+                    ...executeOptions,
+                    authRetryAttempted: true,
+                });
+            }
         }
-        catch {
-            throw new InvalidJsonResponseError(url, response, text);
+
+        // Ask fetchPolicy if we should retry
+        else if (this.fetchPolicy.shouldRetry(request)) {
+            // Ask fetchPolicy how long to wait
+            await sleep(this.fetchPolicy.getRetryDelay(request));
+
+            // Register the retry attempt
+            this.fetchPolicy.registerRetryAttempt(request);
+
+            // Execute the same request again
+            return await this.execute<T>(request, executeOptions);
         }
+
+        throw new HttpError(url, response, text);
+    }
+
+    /**
+     * Fetches the API based on the given HttpRequest object
+     * @param request
+     * @private
+     */
+    private async request(request: HttpRequest): Promise<Response> {
+        const url = `${this.baseUrl}/${request.path}`;
+        const authHeaders = await this.auth.getHttpHeaders();
+
+        this.events.emit('preFetch', {
+            ...request,
+            url,
+        });
+
+        let headers: Record<string, string> = {
+            Accept: 'application/vnd.api+json',
+        };
+
+        if (request.method === 'POST') {
+            headers = {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+            };
+        }
+
+        const response = await fetch(url, {
+            ...request.options,
+            method: request.method,
+            headers: new Headers({
+                ...authHeaders,
+                ...headers,
+            }),
+        });
+
+        this.events.emit('postFetch', {
+            ...request,
+            url,
+        });
+
+        return response;
     }
 }

--- a/src/JsonApi.ts
+++ b/src/JsonApi.ts
@@ -10,6 +10,7 @@ import { container } from './facades/container';
 import { events } from './facades/events';
 import macros from './facades/macros';
 import MacroRegistry from './MacroRegistry';
+import DefaultFetchPolicy from './policies/DefaultFetchPolicy';
 import QueryBuilder from './QueryBuilder';
 
 export default class JsonApi {
@@ -25,8 +26,12 @@ export default class JsonApi {
         });
 
         c.singleton('config', () => {
-            return new Config({
-                ...{ tokenExpirySafetyWindow: 60000 },
+            return new Config<ConfigAttributes>({
+                ...{
+                    tokenExpirySafetyWindow: 60000,
+                    maxRetries: 2,
+                    retryDelay: 1000,
+                },
                 ...configAttributes,
             });
         });
@@ -54,9 +59,15 @@ export default class JsonApi {
             );
         });
 
+        c.singleton('fetchPolicy', () => {
+            return new DefaultFetchPolicy();
+        });
+
         c.singleton('client', () => {
             return new Client(
                 c.make('auth'),
+                c.make('fetchPolicy'),
+                events(),
                 config().get('baseUrl'),
             );
         });

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -461,10 +461,11 @@ export default class QueryBuilder<T extends Model> implements QueryBuilderInterf
 
         if (this.response.meta) {
             meta = {
+                ...meta,
                 count: this.response.meta.count || 0,
                 pages: this.pageLimit ? Math.ceil(this.response.meta.count / this.pageLimit) : 1,
                 perPage: this.pageLimit ? this.pageLimit : this.response.meta.count,
-                ...meta,
+                original: this.response.meta,
             };
         }
 

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -380,25 +380,20 @@ export default class QueryBuilder<T extends Model> implements QueryBuilderInterf
      * Executes the query (GET)
      */
     private async performGetRequest(path: string) {
-        this.events.emit('preFetch', { queryBuilder: this, url: path });
-
-        const response = await this.client.get(path, {
+        return await this.client.get(path, {
             cache: this.cachePolicy,
         });
-
-        this.events.emit('postFetch', { queryBuilder: this, url: path });
-
-        return response;
     }
 
     /**
      * Fetches the endpoint and uses the raw response to pass to the mapper
      */
     public async getRaw(): Promise<T> {
-        const response = await this.performGetRequest(this.buildUrl(this.endpoint));
+        const url = this.buildUrl(this.endpoint);
+        const response = await this.performGetRequest(url);
 
         if (!isRawResponse(response)) {
-            throw new InvalidResponseError();
+            throw new InvalidResponseError(url);
         }
 
         if (!this.mapper) {

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -373,7 +373,7 @@ export default class QueryBuilder<T extends Model> implements QueryBuilderInterf
      */
     private buildUrl(path: string): string {
         const queryString = (makeSearchParams(this.queryParams)).toString();
-        return `${this.locale ? `${this.locale}/` : ''}${path}/${queryString ? `?${queryString}` : ''}`;
+        return `${this.locale ? `${this.locale}/` : ''}${path}${queryString ? `?${queryString}` : ''}`;
     }
 
     /**

--- a/src/auth/OAuth.ts
+++ b/src/auth/OAuth.ts
@@ -84,7 +84,9 @@ export default class OAuth implements AuthInterface {
     /**
      * Generates a new auth token, stores it as properties and returns it
      */
-    private async generateAuthToken(): Promise<string> {
+    public async generateAuthToken(): Promise<string> {
+        this.events.emit('generatingAuthToken');
+
         const url = `${this.baseUrl}/oauth/token`;
 
         const requestBody = new FormData();

--- a/src/contracts/AuthInterface.ts
+++ b/src/contracts/AuthInterface.ts
@@ -5,6 +5,11 @@ export interface AuthInterface {
     getAuthToken: () => Promise<string>
 
     /**
+     * Generates an auth token
+     */
+    generateAuthToken: () => Promise<string>
+
+    /**
      * Gets the HTTP headers
      */
     getHttpHeaders: () => Promise<Record<string, string>>

--- a/src/contracts/ClientInterface.ts
+++ b/src/contracts/ClientInterface.ts
@@ -1,10 +1,12 @@
+import type { HttpRequestOptions, HttpRequestPath } from '../types/request';
+
 export interface ClientInterface {
     /**
      * Fetches the given path with a GET request
      * @param path
      * @param options
      */
-    get: <T>(path: string, options?: Record<string, unknown>) => Promise<T>
+    get: <T>(path: HttpRequestPath, options?: HttpRequestOptions) => Promise<T>
 
     /**
      * Fetches the given path with a POST request
@@ -12,5 +14,5 @@ export interface ClientInterface {
      * @param body
      * @param options
      */
-    post: <T>(path: string, body: object, options?: RequestInit) => Promise<T>
+    post: <T>(path: HttpRequestPath, body: object, options?: HttpRequestOptions) => Promise<T>
 }

--- a/src/contracts/FetchPolicyInterface.ts
+++ b/src/contracts/FetchPolicyInterface.ts
@@ -1,0 +1,21 @@
+import type { HttpRequest } from '../types/request';
+
+export interface FetchPolicyInterface {
+    /**
+     * Should retry on failure?
+     * @param name
+     * @param call
+     */
+    shouldRetry: (request: HttpRequest) => boolean
+
+    /**
+     * Get the amount of milliseconds to wait between retries
+     * @param request
+     */
+    getRetryDelay: (request: HttpRequest) => number
+
+    /**
+     * Method that will be called when the client attempts to retry a request
+     */
+    registerRetryAttempt: (request: HttpRequest) => void
+}

--- a/src/facades/container.ts
+++ b/src/facades/container.ts
@@ -2,6 +2,7 @@ import type Config from '../Config';
 import type { AuthInterface } from '../contracts/AuthInterface';
 import type { ClientInterface } from '../contracts/ClientInterface';
 import type { EventBusInterface } from '../contracts/EventBusInterface';
+import type { FetchPolicyInterface } from '../contracts/FetchPolicyInterface';
 import type { MacroRegistryInterface } from '../contracts/MacroRegistryInterface';
 import type { QueryBuilderInterface } from '../contracts/QueryBuilderInterface';
 import type { ConfigAttributes } from '../types/config-attributes';
@@ -13,6 +14,7 @@ import { Container } from '../Container';
 interface AppBindings extends ContainerFactoryMap {
     config: () => Config<ConfigAttributes>
     client: () => ClientInterface
+    fetchPolicy: () => FetchPolicyInterface
     auth: () => AuthInterface
     events: () => EventBusInterface<TEventMap>
     query: (endpoint: string, mapper: TMapper<any>) => QueryBuilderInterface<any>

--- a/src/policies/DefaultFetchPolicy.ts
+++ b/src/policies/DefaultFetchPolicy.ts
@@ -1,0 +1,50 @@
+import type { FetchPolicyInterface } from '../contracts/FetchPolicyInterface';
+import type { HttpRequest, HttpRequestMethod } from '../types/request';
+import config from '../facades/config';
+import { events } from '../facades/events';
+
+export default class DefaultFetchPolicy implements FetchPolicyInterface {
+    private retries: Map<HttpRequestMethod, Map<string, number>> = new Map();
+
+    public registerRetryAttempt(request: HttpRequest): void {
+        const { method, path } = request;
+
+        if (!this.retries.get(method)) {
+            this.retries.set(method, new Map());
+        }
+
+        if (!this.retries.get(method).get(path)) {
+            this.retries.get(method).set(path, 0);
+        }
+
+        const retries = this.retries.get(method).get(path);
+
+        const attempt = retries + 1;
+        events().emit('retry', {
+            request,
+            attempt,
+        });
+
+        this.retries.get(method).set(path, attempt);
+    }
+
+    public getRetryDelay(_request: HttpRequest): number {
+        return config().get('retryDelay');
+    }
+
+    public shouldRetry(request: HttpRequest): boolean {
+        const maxRetries = config().get('maxRetries');
+
+        return maxRetries > 0 && maxRetries > this.getRetriesForRequest(request);
+    }
+
+    private getRetriesForRequest(request: HttpRequest): number {
+        const { method, path } = request;
+
+        if (!this.retries.get(method) || !this.retries.get(method).get(path)) {
+            return 0;
+        }
+
+        return this.retries.get(method).get(path);
+    }
+}

--- a/src/types/config-attributes.ts
+++ b/src/types/config-attributes.ts
@@ -5,4 +5,6 @@ export interface ConfigAttributes extends Record<string, ConfigValue> {
     clientId: string
     clientSecret: string
     tokenExpirySafetyWindow?: number
+    maxRetries?: number
+    retryDelay?: number
 }

--- a/src/types/event-bus.ts
+++ b/src/types/event-bus.ts
@@ -1,12 +1,25 @@
 import type QueryBuilder from '../QueryBuilder';
 import type { TQueryParamValue } from './query-params';
+import type { HttpRequest } from './request';
+
+interface RequestEvent extends HttpRequest {
+    url: string
+}
 
 export interface TEventMap {
     paramAdded: { queryBuilder: QueryBuilder<any>, name: string, value: TQueryParamValue }
-    preFetch: { queryBuilder: QueryBuilder<any>, url: string }
-    postFetch: { queryBuilder: QueryBuilder<any>, url: string }
+
+    preFetch: RequestEvent
+    postFetch: RequestEvent
+    retry: {
+        request: HttpRequest
+        attempt: number
+    }
+
     preFind: { queryBuilder: QueryBuilder<any>, uuid: string | number }
     postFind: { queryBuilder: QueryBuilder<any>, uuid: string | number, result: unknown }
+
+    generatingAuthToken: null
     authTokenGenerated: { token: string, expiryTime: number }
 }
 

--- a/src/types/fetch-retry.ts
+++ b/src/types/fetch-retry.ts
@@ -1,0 +1,1 @@
+export type FetchRetry<T> = () => Promise<T>;

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -1,0 +1,11 @@
+export interface HttpRequest {
+    path: string
+    method: HttpRequestMethod
+    options?: Partial<RequestInit>
+}
+
+export type HttpRequestOptions = HttpRequest['options'];
+export type HttpRequestPath = HttpRequest['path'];
+
+export type HttpRequestMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' |
+    'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH';

--- a/src/types/resultset-meta.ts
+++ b/src/types/resultset-meta.ts
@@ -13,4 +13,5 @@ export interface TResultSetMeta {
     pages?: number
     perPage?: number
     excludedByGate?: number
+    original?: Record<string, unknown>
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,3 @@
+export async function sleep(ms: number): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/tests/macro-registry.test.ts
+++ b/tests/macro-registry.test.ts
@@ -26,7 +26,7 @@ it('correctly executes registered macros', () => {
     const queryBuilder = makeQueryBuilder();
     queryBuilder.macro('macroName');
 
-    expect(queryBuilder.toString()).toBe('api/endpoint/?page%5Blimit%5D=333');
+    expect(queryBuilder.toString()).toBe('api/endpoint?page%5Blimit%5D=333');
 });
 
 it('throws an UnknownMacroError when executing non-existent macros', () => {

--- a/tests/querybuilder.test.ts
+++ b/tests/querybuilder.test.ts
@@ -3,16 +3,21 @@ import OAuth from '../src/auth/OAuth';
 import Client from '../src/Client';
 import EventBus from '../src/EventBus';
 import MacroRegistry from '../src/MacroRegistry';
+import DefaultFetchPolicy from '../src/policies/DefaultFetchPolicy';
 import QueryBuilder from '../src/QueryBuilder';
 
 function makeMockClient() {
+    const eventBus = new EventBus<TEventMap>();
+
     return new Client(
         new OAuth(
             'https://baseurl.ext',
             'test',
             'test',
-            new EventBus<TEventMap>(),
+            eventBus,
         ),
+        new DefaultFetchPolicy(),
+        eventBus,
         'https://baseurl.ext',
     );
 }

--- a/tests/querybuilder.test.ts
+++ b/tests/querybuilder.test.ts
@@ -31,18 +31,18 @@ it('result of query builder starts with the endpoint', () => {
     const queryBuilder = makeQueryBuilder();
     expect(queryBuilder.toString()).toMatch(/^(api\/endpoint)/);
 
-    expect(queryBuilder.toString()).toBe('api/endpoint/');
+    expect(queryBuilder.toString()).toBe('api/endpoint');
 });
 
 it('a new query has pagination params by default', () => {
     const queryBuilder = makeQueryBuilder();
-    expect(queryBuilder.toString()).toBe('api/endpoint/');
+    expect(queryBuilder.toString()).toBe('api/endpoint');
 });
 
 it('adds param', () => {
     const queryBuilder = makeQueryBuilder();
     queryBuilder.param('testParam', 'testValue');
-    expect(queryBuilder.toString()).toBe('api/endpoint/?testParam=testValue');
+    expect(queryBuilder.toString()).toBe('api/endpoint?testParam=testValue');
 });
 
 it('adds multiple params', () => {
@@ -51,7 +51,7 @@ it('adds multiple params', () => {
         test1: 'test1Value',
         test2: 'test2Value',
     });
-    expect(queryBuilder.toString()).toBe('api/endpoint/?test1=test1Value&test2=test2Value');
+    expect(queryBuilder.toString()).toBe('api/endpoint?test1=test1Value&test2=test2Value');
 });
 
 it('params with the same name get overwritten', () => {
@@ -61,39 +61,39 @@ it('params with the same name get overwritten', () => {
         test2: 'test2Value',
     });
     queryBuilder.param('test2', 'anotherTestValue');
-    expect(queryBuilder.toString()).toBe('api/endpoint/?test1=test1Value&test2=anotherTestValue');
+    expect(queryBuilder.toString()).toBe('api/endpoint?test1=test1Value&test2=anotherTestValue');
 });
 
 it('setting locale prepends the locale', () => {
     const queryBuilder = makeQueryBuilder();
     queryBuilder.setLocale('nl');
-    expect(queryBuilder.toString()).toBe('nl/api/endpoint/');
+    expect(queryBuilder.toString()).toBe('nl/api/endpoint');
 });
 
 it('where adds the appropriate params', () => {
     const queryBuilder = makeQueryBuilder();
     queryBuilder.where('name', '=', 'Rein');
-    expect(queryBuilder.toString()).toBe('api/endpoint/?filter%5Bg1%5D%5Bcondition%5D%5Bpath%5D=name&filter%5Bg1%5D%5Bcondition%5D%5Boperator%5D=%3D&filter%5Bg1%5D%5Bcondition%5D%5Bvalue%5D=Rein');
+    expect(queryBuilder.toString()).toBe('api/endpoint?filter%5Bg1%5D%5Bcondition%5D%5Bpath%5D=name&filter%5Bg1%5D%5Bcondition%5D%5Boperator%5D=%3D&filter%5Bg1%5D%5Bcondition%5D%5Bvalue%5D=Rein');
 });
 
 it('includes adds the appropriate params', () => {
     const queryBuilder = makeQueryBuilder();
     queryBuilder.include(['testInclude1', 'testInclude2', 'testInclude3']);
-    expect(queryBuilder.toString()).toBe('api/endpoint/?jsonapi_include=1&include=testInclude1%2CtestInclude2%2CtestInclude3');
+    expect(queryBuilder.toString()).toBe('api/endpoint?jsonapi_include=1&include=testInclude1%2CtestInclude2%2CtestInclude3');
 });
 
 it('paginate adds the appropriate params', () => {
     const queryBuilder = makeQueryBuilder();
     queryBuilder.paginate(1, 10);
-    expect(queryBuilder.toString()).toBe('api/endpoint/?page%5Boffset%5D=0&page%5Blimit%5D=10');
+    expect(queryBuilder.toString()).toBe('api/endpoint?page%5Boffset%5D=0&page%5Blimit%5D=10');
     queryBuilder.paginate(2, 10);
-    expect(queryBuilder.toString()).toBe('api/endpoint/?page%5Boffset%5D=10&page%5Blimit%5D=10');
+    expect(queryBuilder.toString()).toBe('api/endpoint?page%5Boffset%5D=10&page%5Blimit%5D=10');
 });
 
 it('sort adds the appropriate params', () => {
     const queryBuilder = makeQueryBuilder();
     queryBuilder.sort('name', 'asc');
-    expect(queryBuilder.toString()).toBe('api/endpoint/?sort%5Bg1%5D%5Bpath%5D=name&sort%5Bg1%5D%5Bdirection%5D=asc');
+    expect(queryBuilder.toString()).toBe('api/endpoint?sort%5Bg1%5D%5Bpath%5D=name&sort%5Bg1%5D%5Bdirection%5D=asc');
 });
 
 it('group adds the appropriate params', () => {
@@ -105,5 +105,5 @@ it('group adds the appropriate params', () => {
             qb.where('age', '>', '34');
         });
     });
-    expect(queryBuilder.toString()).toBe('api/endpoint/?filter%5Bg1%5D%5Bgroup%5D%5Bconjunction%5D=OR&filter%5Bg2%5D%5Bcondition%5D%5BmemberOf%5D=g1&filter%5Bg2%5D%5Bcondition%5D%5Bpath%5D=name&filter%5Bg2%5D%5Bcondition%5D%5Boperator%5D=%3D&filter%5Bg2%5D%5Bcondition%5D%5Bvalue%5D=Rein&filter%5Bg3%5D%5Bcondition%5D%5BmemberOf%5D=g1&filter%5Bg3%5D%5Bcondition%5D%5Bpath%5D=name&filter%5Bg3%5D%5Bcondition%5D%5Boperator%5D=%3D&filter%5Bg3%5D%5Bcondition%5D%5Bvalue%5D=Gilke&filter%5Bg4%5D%5Bcondition%5D%5BmemberOf%5D=g1&filter%5Bg4%5D%5Bgroup%5D%5Bconjunction%5D=AND&filter%5Bg5%5D%5Bcondition%5D%5BmemberOf%5D=g4&filter%5Bg5%5D%5Bcondition%5D%5Bpath%5D=age&filter%5Bg5%5D%5Bcondition%5D%5Boperator%5D=%3E&filter%5Bg5%5D%5Bcondition%5D%5Bvalue%5D=34');
+    expect(queryBuilder.toString()).toBe('api/endpoint?filter%5Bg1%5D%5Bgroup%5D%5Bconjunction%5D=OR&filter%5Bg2%5D%5Bcondition%5D%5BmemberOf%5D=g1&filter%5Bg2%5D%5Bcondition%5D%5Bpath%5D=name&filter%5Bg2%5D%5Bcondition%5D%5Boperator%5D=%3D&filter%5Bg2%5D%5Bcondition%5D%5Bvalue%5D=Rein&filter%5Bg3%5D%5Bcondition%5D%5BmemberOf%5D=g1&filter%5Bg3%5D%5Bcondition%5D%5Bpath%5D=name&filter%5Bg3%5D%5Bcondition%5D%5Boperator%5D=%3D&filter%5Bg3%5D%5Bcondition%5D%5Bvalue%5D=Gilke&filter%5Bg4%5D%5Bcondition%5D%5BmemberOf%5D=g1&filter%5Bg4%5D%5Bgroup%5D%5Bconjunction%5D=AND&filter%5Bg5%5D%5Bcondition%5D%5BmemberOf%5D=g4&filter%5Bg5%5D%5Bcondition%5D%5Bpath%5D=age&filter%5Bg5%5D%5Bcondition%5D%5Boperator%5D=%3E&filter%5Bg5%5D%5Bcondition%5D%5Bvalue%5D=34');
 });


### PR DESCRIPTION
This is a small QoL feature with new config options:

* maxRetries?: number // Max amount of retries, default = 2, setting to 0 disables retries
* retryDelay?: number // The delay (in ms) between retries

The client will now retry failed requests (replay request), taking these options into account

* When server responds 429 (Too Many Requests) we respect it and don't do any retries
* When server responds with 401 (Unauthorized), we don't do retries immediately, but we will generate a new auth token and then retry the request

Also updated the README.md